### PR TITLE
[Hotfix] Fix producer idempotence + acks conflict (#16)

### DIFF
--- a/streaming/producer/producer.py
+++ b/streaming/producer/producer.py
@@ -37,7 +37,7 @@ KAFKA_CONF = {
     "bootstrap.servers": BROKER,
 
     # Reliability vs Speed (ideal for real-time ticker data)
-    "enable.idempotence": True,      # Prevents duplicates during retry
+    "enable.idempotence": False,      # Disabled because idempotence requires acks='all'; for low-latency streaming we keep acks='1'
     "acks": "1",                      # Faster than "all", acceptable for market ticks
     "retries": 5,
     "retry.backoff.ms": 200,


### PR DESCRIPTION
## ✨ What
- Kafka Producer 설정 오류를 수정하고 서비스가 정상 재시작되도록 hotfix 적용
- `enable.idempotence=True` 와 `acks=1` 충돌 문제 해결

## 🎯 Why
- `enable.idempotence=True` 는 `acks=all` 과 반드시 함께 사용해야 하므로
  현재 구조(싱글 노드 + 실시간 지연 최소화 우선)에서는 오류 발생  
- Producer 서비스가 systemd에서 계속 crash → 즉각적인 hotfix 필요  
- Closes #16 

## 📌 Changes
- `enable.idempotence` 값을 `False` 로 변경  
- 주석 수정하여 왜 비활성화했는지 명확히 설명  
- Producer 서비스 재시작 후 정상 동작 확인

## 🧪 Test
- `sudo systemctl restart upbit-producer` 실행  
- `sudo journalctl -u upbit-producer -f` 로 정상 실행 여부 확인  
- Kafka 연결 에러 및 crash loop가 사라졌는지 검증

## 🤔 Review Point
- 현재 구조(싱글 Redpanda 브로커) 기준에서 idempotence 비활성화가 적절한 선택인지  
- 이후 multi-node 운영 시 다시 켜야 할 가능성 고려해야 함
