### PR TITLE
chore: increase ruff line-length to 130 (#23)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-line-length = 100
+line-length = 130
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]


### PR DESCRIPTION
## ✨ What
- ruff line-length를 130으로 조정

## 🎯 Why
- 배치 DAG의 한국어 docstring 특성상 E501이 반복 발생하여 CI noise를 줄이기 위함
- 팀 합의 완료
- Closes #23 

## 📌 Changes
- ruff 설정(line-length)만 변경
- 로직 변경 없음

## 🧪 Test
- CI에서 ruff check 통과 여부로 확인

## 🤔 Review Point
- 팀 합의 하에 적용된 설정 변경입니다.
