### PR TITLE
feat: make S3 -> Snowflake Silver DAG daily (#45)

### DIFF
--- a/batch/dags/silver/batch_candle_to_silver_dag.py
+++ b/batch/dags/silver/batch_candle_to_silver_dag.py
@@ -187,7 +187,7 @@ def load_candles_to_snowflake(ds, **context):
     # -------------------------------------------------------------------
     conn = snowflake_hook.get_conn()
     cur = conn.cursor()
-
+    cur.execute("USE WAREHOUSE DATA_TEAM_WH")
     cur.execute("USE DATABASE UPBIT_DB")
     cur.execute("USE SCHEMA SILVER")
 
@@ -197,6 +197,7 @@ def load_candles_to_snowflake(ds, **context):
         table_name=TARGET_TABLE,
         database="UPBIT_DB",
         schema="SILVER",
+        use_logical_type=True,
     )
 
     logging.info(
@@ -211,7 +212,7 @@ with DAG(
     dag_id="batch_candle_to_silver_dag",
     default_args=default_args,
     description="Load batch candle data from S3 into Snowflake Silver layer",
-    schedule_interval=None,
+    schedule_interval="@daily",
     catchup=False,
     max_active_runs=1,
     concurrency=1,

--- a/batch/dags/silver/batch_trade_to_silver_dag.py
+++ b/batch/dags/silver/batch_trade_to_silver_dag.py
@@ -170,6 +170,7 @@ def load_trades_to_snowflake(ds, **context):
 
     conn = snowflake_hook.get_conn()
     cur = conn.cursor()
+    cur.execute("USE WAREHOUSE DATA_TEAM_WH")
     cur.execute("USE DATABASE UPBIT_DB")
     cur.execute("USE SCHEMA SILVER")
 
@@ -179,6 +180,7 @@ def load_trades_to_snowflake(ds, **context):
         table_name=TARGET_TABLE,
         database="UPBIT_DB",
         schema="SILVER",
+        use_logical_type=True,
     )
 
     logging.info(f"Snowflake write complete: success={success}, rows={nrows}")
@@ -188,7 +190,7 @@ with DAG(
     dag_id="batch_trade_to_silver_dag",
     default_args=default_args,
     description="Load batch trade data from S3 into Snowflake Silver layer",
-    schedule_interval=None,
+    schedule_interval="@daily",
     catchup=False,
     max_active_runs=1,
     concurrency=1,


### PR DESCRIPTION
## ✨ What
- S3에 적재된 Upbit batch trade / candle 데이터를 Snowflake Silver로 적재하는 DAG 추가

## 🎯 Why
- Batch Raw(S3) → Silver(Snowflake) 파이프라인 검증
- 이후 Gold / Alert 작업을 위한 Silver 데이터 준비  
- Closes #45

## 📌 Changes
- `batch_trade_to_silver_dag.py` 추가
- `batch_candle_to_silver_dag.py` EC2 환경 테스트 완료

## 🧪 Test
- 로컬 Airflow(Docker)에서 `airflow tasks test`
- EC2 Airflow Scheduler에서 trade / candle DAG 실행 확인
- Snowflake Silver 테이블 적재 결과 확인

## 🤔 Review Point
- 현재 append-only 구조 (idempotency는 추후 개선 가능)
- 상세 설계 및 테스트 로그는 Notion에 정리
