### PR TITLE
fix: noramlize candle and trade timestamps for Snowflake compatibility (#63)

### DIFF
--- a/batch/dags/silver/batch_candle_to_silver_dag.py
+++ b/batch/dags/silver/batch_candle_to_silver_dag.py
@@ -110,7 +110,7 @@ def load_candles_to_snowflake(ds, **context):
         df = table.to_pandas()
 
         df["CANDLE_INTERVAL"] = get_candle_interval(key)
-        df["INGESTION_TIME"] = datetime.utcnow()
+        df["INGESTION_TIME"] = pd.Timestamp.utcnow().tz_localize(None)
 
         all_dataframes.append(df)
 
@@ -138,7 +138,6 @@ def load_candles_to_snowflake(ds, **context):
         unified_df["CANDLE_TS"],
         unit="ms",
         utc=True,
-        errors="coerce",
     )
 
     if unified_df["CANDLE_TS"].isna().any():

--- a/batch/dags/silver/batch_trade_to_silver_dag.py
+++ b/batch/dags/silver/batch_trade_to_silver_dag.py
@@ -120,7 +120,6 @@ def load_trades_to_snowflake(ds, **context):
         unified_df["TRADE_TS"],
         unit="ms",
         utc=True,
-        errors="coerce",
     )
 
     if unified_df["TRADE_TS"].isna().any():
@@ -142,7 +141,7 @@ def load_trades_to_snowflake(ds, **context):
     )
 
     # Ingestion and lineage
-    unified_df["INGESTION_TIME"] = datetime.utcnow()
+    unified_df["INGESTION_TIME"] = pd.Timestamp.utcnow().tz_localize(None)
     unified_df["SOURCE"] = "batch_trade"
 
     # Optional columns may not exist depending on upstream


### PR DESCRIPTION
## ✨ What
- Silver Candle / Trade DAG의 timestamp 처리 로직 수정

## 🎯 Why
- Snowflake 적재 시 invalid date 발생 문제 해결
- Closes #63 

## 📌 Changes
- epoch ms timestamp를 UTC 기준 timezone-naive로 정규화
- INGESTION_TIME 처리 방식 통일

## 🧪 Test
- Airflow DAG 수동 실행
- Snowflake SILVER 테이블 timestamp 컬럼 확인

## 🤔 Review Point
- Silver layer에서 timestamp 정합성 보장
