### PR TITLE
Fix: unify Silver timestamp handling (KST-based) (#71)

### DIFF
--- a/batch/dags/silver/batch_candle_to_silver_dag.py
+++ b/batch/dags/silver/batch_candle_to_silver_dag.py
@@ -112,7 +112,6 @@ def load_candles_to_snowflake(ds, **context):
         df = table.to_pandas()
 
         df["CANDLE_INTERVAL"] = get_candle_interval(key)
-        df["INGESTION_TIME"] = pd.Timestamp.utcnow().tz_localize(None)
 
         all_dataframes.append(df)
 
@@ -126,7 +125,7 @@ def load_candles_to_snowflake(ds, **context):
     unified_df = unified_df.rename(
         columns={
             "market": "CODE",
-            "timestamp": "CANDLE_TS",
+            "candle_date_time_kst": "CANDLE_TS",
             "opening_price": "OPEN_PRICE",
             "high_price": "HIGH_PRICE",
             "low_price": "LOW_PRICE",
@@ -135,32 +134,22 @@ def load_candles_to_snowflake(ds, **context):
         }
     )
 
-    # Explicit timestamp parsing (Upbit candle timestamp = epoch ms)
-    unified_df["CANDLE_TS"] = pd.to_datetime(
-        unified_df["CANDLE_TS"],
-        unit="ms",
-        utc=True,
-    )
-
-    if unified_df["CANDLE_TS"].isna().any():
-        raise ValueError("CANDLE_TS contains invalid values after parsing")
 
     # Derived Silver columns
     unified_df["TRADE_PRICE"] = unified_df["CLOSE_PRICE"]
-    unified_df["TRADE_DATE"] = (
-        unified_df["CANDLE_TS"]
-        .dt.tz_convert("Asia/Seoul")
-        .dt.date
-    )
+
+    # CANDLE_TS: KST candle timestamp
+    unified_df["CANDLE_TS"] = pd.to_datetime(unified_df["CANDLE_TS"])
+    
+    if unified_df["CANDLE_TS"].isna().any():
+        raise ValueError("CANDLE_TS contains invalid values after parsing")
+
+    # TRADE_DATE: CANDLE_TS to date
+    unified_df["TRADE_DATE"] = unified_df["CANDLE_TS"].dt.date
 
     # ============================
     # Snowflake write stabilization
     # ============================
-    unified_df["CANDLE_TS"] = (
-        unified_df["CANDLE_TS"]
-        .dt.tz_convert("UTC")
-        .dt.tz_localize(None)
-    )
 
     unified_df["SOURCE"] = "UPBIT_BATCH"
 
@@ -175,7 +164,6 @@ def load_candles_to_snowflake(ds, **context):
         "VOLUME",
         "TRADE_PRICE",
         "TRADE_DATE",
-        "INGESTION_TIME",
         "SOURCE",
     ]
 

--- a/batch/dags/silver/batch_trade_to_silver_dag.py
+++ b/batch/dags/silver/batch_trade_to_silver_dag.py
@@ -25,6 +25,9 @@ import logging
 from SlackAlert import send_slack_failure_callback
 
 
+# -------------------------------------------------------------------
+# DAG default arguments
+# -------------------------------------------------------------------
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
@@ -33,15 +36,21 @@ default_args = {
     "email_on_retry": False,
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
-    'on_failure_callback': send_slack_failure_callback
+    "on_failure_callback": send_slack_failure_callback,
 }
 
 
+# -------------------------------------------------------------------
+# Configuration
+# -------------------------------------------------------------------
 S3_BUCKET = "team6-batch"
 SNOWFLAKE_CONN_ID = "snowflake_conn_id"
 TARGET_TABLE = "SILVER_TRADES"
 
 
+# -------------------------------------------------------------------
+# Main task logic
+# -------------------------------------------------------------------
 def load_trades_to_snowflake(ds, **context):
     """
     Load daily trade parquet files from S3 into Snowflake Silver table.
@@ -61,12 +70,8 @@ def load_trades_to_snowflake(ds, **context):
     logging.info(f"Listing S3 objects with prefix: {prefix}")
 
     keys = s3_hook.list_keys(bucket_name=S3_BUCKET, prefix=prefix) or []
+    trade_files = [key for key in keys if "trade" in key]
 
-    # trade parquet filename may vary slightly depending on upstream
-    trade_files = [
-        key for key in keys
-        if key.endswith("trade.parquet") or "trade" in key
-    ]
     if not trade_files:
         logging.info("No trade files found for this execution date.")
         return
@@ -82,15 +87,12 @@ def load_trades_to_snowflake(ds, **context):
         table = pq.read_table(io.BytesIO(parquet_bytes))
         df = table.to_pandas()
 
-        # Debug: log raw columns
-        logging.debug(f"Raw trade columns: {df.columns.tolist()}")
-
         all_dataframes.append(df)
 
     unified_df = pd.concat(all_dataframes, ignore_index=True)
     logging.info(f"Total records loaded from S3: {len(unified_df)}")
 
-    # detect timestamp column (upstream schema may vary)
+    # Detect timestamp column (schema may vary upstream)
     if "trade_timestamp" in unified_df.columns:
         ts_col = "trade_timestamp"
     elif "timestamp" in unified_df.columns:
@@ -98,12 +100,7 @@ def load_trades_to_snowflake(ds, **context):
     else:
         raise ValueError("No timestamp column found in raw trade data")
 
-    raw_required = ["market", ts_col, "trade_price", "trade_volume"]
-    missing_raw = [c for c in raw_required if c not in unified_df.columns]
-    if missing_raw:
-        raise ValueError(f"Missing required raw columns: {missing_raw}")
-
-    # Raw → Silver mapping (Notion schema)
+    # Raw → Silver mapping
     unified_df = unified_df.rename(
         columns={
             "market": "CODE",
@@ -117,7 +114,10 @@ def load_trades_to_snowflake(ds, **context):
         }
     )
 
-    # Explicit timestamp parsing (epoch ms)
+    # -------------------------------------------------------------------
+    # Timestamp handling
+    # -------------------------------------------------------------------
+    # Epoch(ms) → UTC tz-aware
     unified_df["TRADE_TS"] = pd.to_datetime(
         unified_df["TRADE_TS"],
         unit="ms",
@@ -127,28 +127,26 @@ def load_trades_to_snowflake(ds, **context):
     if unified_df["TRADE_TS"].isna().any():
         raise ValueError("TRADE_TS contains invalid values after parsing")
 
+    # TRADE_DATE derived in KST
     unified_df["TRADE_DATE"] = (
         unified_df["TRADE_TS"]
         .dt.tz_convert("Asia/Seoul")
         .dt.date
     )
 
-    # ============================
-    # Snowflake write stabilization
-    # ============================
-    unified_df["TRADE_TS"] = (
-        unified_df["TRADE_TS"]
-        .dt.tz_convert("UTC")
-        .dt.tz_localize(None)
-    )
+    # Snowflake write stabilization (UTC tz-naive)
+    unified_df["TRADE_TS"] = unified_df["TRADE_TS"].dt.tz_localize(None)
 
-    # Ingestion and lineage
-    unified_df["INGESTION_TIME"] = pd.Timestamp.utcnow().tz_localize(None)
-    unified_df["SOURCE"] = "batch_trade"
+    # Lineage
+    unified_df["SOURCE"] = "UPBIT_BATCH"
 
-    # Optional columns may not exist depending on upstream
-    # If missing, create them as null to keep Snowflake insert consistent
-    optional_cols = ["PREV_CLOSING_PRICE", "CHANGE_PRICE", "ASK_BID", "SEQUENTIAL_ID"]
+    # Optional columns (ensure schema consistency)
+    optional_cols = [
+        "PREV_CLOSING_PRICE",
+        "CHANGE_PRICE",
+        "ASK_BID",
+        "SEQUENTIAL_ID",
+    ]
     for col in optional_cols:
         if col not in unified_df.columns:
             unified_df[col] = None
@@ -163,21 +161,17 @@ def load_trades_to_snowflake(ds, **context):
         "CHANGE_PRICE",
         "ASK_BID",
         "SEQUENTIAL_ID",
-        "INGESTION_TIME",
         "SOURCE",
     ]
-
-    missing = set(expected_columns) - set(unified_df.columns)
-    if missing:
-        raise ValueError(f"Missing expected columns: {missing}")
 
     unified_df = unified_df[expected_columns]
 
     logging.info("==== TRADE_DATE SAMPLE ====")
     logging.info(unified_df[["TRADE_TS", "TRADE_DATE"]].head().to_string())
-    logging.info("==== TRADE_DATE COUNTS ====")
-    logging.info(unified_df["TRADE_DATE"].value_counts().head().to_string())
 
+    # -------------------------------------------------------------------
+    # Snowflake write (append-only)
+    # -------------------------------------------------------------------
     conn = snowflake_hook.get_conn()
     cur = conn.cursor()
     cur.execute("USE WAREHOUSE COMPUTE_WH")
@@ -196,11 +190,14 @@ def load_trades_to_snowflake(ds, **context):
     logging.info(f"Snowflake write complete: success={success}, rows={nrows}")
 
 
+# -------------------------------------------------------------------
+# DAG definition
+# -------------------------------------------------------------------
 with DAG(
     dag_id="batch_trade_to_silver_dag",
     default_args=default_args,
     description="Load batch trade data from S3 into Snowflake Silver layer",
-    schedule_interval="0 1  * * *", # UTC 01:00 = KST 10:00
+    schedule_interval="0 1 * * *",  # UTC 01:00 = KST 10:00
     catchup=False,
     max_active_runs=1,
     concurrency=1,


### PR DESCRIPTION
## ✨ What
- Batch Candle / Trade Silver DAG 타임스탬프 처리 로직 수정

## 🎯 Why
- Silver 레이어에서 시간대 기준을 KST로 통일하기 위함
- 시각화 및 Gold 집계 시 시간 혼란 방지
- Invalid date 발생 가능성 제거
- Closes #71

## 📌 Changes
- candle_date_time_kst 컬럼을 CANDLE_TS 기준으로 사용
- TRADE_DATE 파생 로직 단순화
- UTC/KST 변환 혼재 제거

## 🧪 Test
- 로컬 DAG 실행
- Snowflake SILVER_CANDLES / SILVER_TRADES 데이터 확인

## 🤔 Review Point
- Silver 레이어에서 KST 기준 타임스탬프 사용이 적절한지

