### PR TITLE
Chore: disable catchup after Silver backfill completion(#77)

### DIFF
--- a/batch/dags/silver/batch_candle_to_silver_dag.py
+++ b/batch/dags/silver/batch_candle_to_silver_dag.py
@@ -220,7 +220,7 @@ with DAG(
     default_args=default_args,
     description="Load batch candle data from S3 into Snowflake Silver layer",
     schedule_interval="0 1 * * *",  # UTC 01:00 = KST 10:00
-    catchup=True,    # TEMP: enable backfill after Silver table recreation
+    catchup=False,    # Backfill completed
     max_active_runs=1,
     concurrency=1,
 ) as dag:

--- a/batch/dags/silver/batch_trade_to_silver_dag.py
+++ b/batch/dags/silver/batch_trade_to_silver_dag.py
@@ -199,7 +199,7 @@ with DAG(
     default_args=default_args,
     description="Load batch trade data from S3 into Snowflake Silver layer",
     schedule_interval="0 1 * * *",  # UTC 01:00 = KST 10:00
-    catchup=True,    # TEMP: enable backfill after Silver table recreation
+    catchup=False,    # Backfill completed
     max_active_runs=1,
     concurrency=1,
 ) as dag:


### PR DESCRIPTION
## ✨ What
- Silver Candle / Trade DAG에서 catchup 설정을 비활성화했습니다.

## 🎯 Why
- Silver 테이블 재적재(backfill)가 완료되어 운영 모드로 전환합니다.
- Closes #77 

## 📌 Changes
- catchup=True → False

## 🧪 Test
- 기존 Silver 데이터 정상 적재 상태 확인
