### PR TITLE
fix: set GOLD schema for dbt gold models (#88)

### DIFF
--- a/batch/dbt/dbt_project.yml
+++ b/batch/dbt/dbt_project.yml
@@ -17,7 +17,9 @@ clean-targets:
 models:
   upbit_dbt:
     silver:
+      +schema: silver
       +materialized: table
 
     gold:
+      +schema: gold
       +materialized: table


### PR DESCRIPTION
## ✨ What
- dbt gold 모델의 스키마를 GOLD로 명시적으로 설정

## 🎯 Why
- 현재 gold 모델이 기본 설정으로 SILVER 스키마에 생성되는 문제 수정
- Closes #88 

## 🧪 Test
- EC2 worker 컨테이너에서 dbt run 실행
- GOLD 스키마에 테이블 생성 확인
