### PR TITLE
fix: override dbt schema naming to use existing GOLD and SILVER schemas

### DIFF
--- a/batch/dbt/macros/generate_schema_name.sql
+++ b/batch/dbt/macros/generate_schema_name.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) %}
+  {{ custom_schema_name | upper }}
+{% endmacro %}


### PR DESCRIPTION
## ✨ What
- dbt 기본 schema prefix 규칙을 비활성화하기 위해 `generate_schema_name` 매크로 추가
- gold / silver 모델이 기존 Snowflake 스키마(GOLD, SILVER)에 직접 생성되도록 수정

## 🎯 Why
- dbt 기본 동작으로 인해 `SILVER_GOLD`와 같은 의도하지 않은 스키마가 생성됨
- 프로젝트에서는 이미 GOLD / SILVER 스키마를 사용 중이어서 prefix 없이 테이블을 생성할 필요가 있음
- Closes #91 

## 📌 Changes
- `batch/dbt/macros/generate_schema_name.sql` 신규 추가
- dbt schema 결정 로직을 프로젝트 요구사항에 맞게 override

## 🧪 Test
- EC2 worker 컨테이너에서 `dbt run --select gold_candle_window_metrics` 실행
- Gold 모델이 `GOLD` 스키마에 정상 생성되는 것 확인

## 🤔 Review Point
- dbt schema prefix를 사용하지 않고 기존 Snowflake 스키마를 그대로 사용하는 방향이 맞는지 확인 부탁드립니다.

