### PR TITLE
[Feature] Add candle_ts to Gold candle window metrics

### DIFF
--- a/batch/dbt/models/gold/gold_candle_window_metrics.sql
+++ b/batch/dbt/models/gold/gold_candle_window_metrics.sql
@@ -16,6 +16,7 @@ window_metrics as (
         code,
         candle_interval,
         trade_date,
+        candle_ts,
         close_price,
 
         avg(close_price) over (
@@ -40,6 +41,7 @@ zscore_calc as (
         code,
         candle_interval,
         trade_date,
+        candle_ts,
         close_price,
         ma_5,
         std_5,


### PR DESCRIPTION
## ✨ What
- Gold candle window metrics 모델에 `candle_ts` 컬럼을 추가

## 🎯 Why
- Gold 데이터를 시계열 기준으로 활용하기 위함
- Closes #97

## 📌 Changes
- `gold_candle_window_metrics.sql`
  - `candle_ts` 컬럼을 final select에 포함

## 🧪 Test
- SQL 변경 내용 검토
- Merge 후 dbt run을 통해 Gold backfill 예정

## 🤔 Review Point
- 기존 계산 로직을 변경하지 않고 컬럼만 확장한 점
