### PR TITLE
fix: align raw source table name casing

### DIFF
--- a/batch/dbt/models/silver/sources.yml
+++ b/batch/dbt/models/silver/sources.yml
@@ -12,4 +12,4 @@ sources:
     database: "{{ env_var('SNOWFLAKE_DATABASE') }}"
     schema: RAW
     tables:
-      - name: RAW_STOCK_HISTORY
+      - name: raw_source_history


### PR DESCRIPTION
## ✨ What
- raw source table name casing 수정

## 🎯 Why
- dbt는 source/table name을 case-sensitive하게 비교하여
  casing 불일치 시 컴파일 단계에서 실패함 
- Closes #101 

## 📌 Changes
- sources.yml의 RAW_STOCK_HISTORY → raw_stock_history

## 🧪 Test
- dbt compile 성공 확인 예정
