### PR TITLE
fix: correct raw source table name typo

### DIFF
--- a/batch/dbt/models/silver/sources.yml
+++ b/batch/dbt/models/silver/sources.yml
@@ -12,4 +12,4 @@ sources:
     database: "{{ env_var('SNOWFLAKE_DATABASE') }}"
     schema: RAW
     tables:
-      - name: raw_source_history
+      - name: raw_stock_history


### PR DESCRIPTION
## ✨ What
- raw source 테이블명 오타 수정

## 🎯 Why
- source 이름 불일치로 인해 dbt compile 단계에서 프로젝트 전체가 실패하던 문제 해결
- Closes #103 

## 📌 Changes
- sources.yml의 raw_source_history → raw_stock_history

## 🧪 Test
- dbt compile 성공 확인 예정
