### PR TITLE
Fix dbt_gold_metrics DAG selector

### DIFF
--- a/batch/dags/gold/dbt_gold_metrics_dag.py
+++ b/batch/dags/gold/dbt_gold_metrics_dag.py
@@ -38,6 +38,6 @@ with DAG(
         bash_command=(
             "cd /opt/dbt && "
             "/opt/dbt_venv/bin/dbt run "
-            "--select gold "
+            "--select gold_candle_window_metrics "
         ),
     )


### PR DESCRIPTION
## ✨ What
- dbt_gold_metrics DAG의 dbt 실행 selector를 gold → gold_candle_window_metrics로 제한

## 🎯 Why
- dbt run --select gold 사용 시 gold 하위 모든 모델을 함께 실행하여
  일부 gold 모델(SQL 오류)로 인해 DAG가 실패하는 문제가 발생  
- Closes #110 

## 📌 Changes
- dbt_gold_metrics_dag.py에서 dbt selector 범위 수정

## 🧪 Test
- EC2 airflow worker에서
/opt/dbt_venv/bin/dbt run --select gold_candle_window_metrics 실행 확인
- Airflow Web UI에서 DAG 실행 시 정상 동작 확인

## 🤔 Review Point
- gold 전체 실행 대신 metrics 단일 모델만 실행하도록 범위를 제한한 점
