### PR TITLE
chore(alert): clarify streaming alert naming

### DIFF
--- a/alerts/alert_worker.py
+++ b/alerts/alert_worker.py
@@ -1,16 +1,18 @@
 """
-Alert Worker v1
+Streaming Price & Volume Alert
 
-- Reads Upbit ticker JSONL from GCS
-- Aggregates ticks into 1-minute bars (close price, volume sum)
-- Compares current 1-minute bar vs SMA of last 5 minutes
-- Sends observation-only alerts to Slack
+- Source: Upbit ticker JSONL stored in GCS
+- Processing: Aggregate ticker events into 1-minute bars (price, volume)
+- Logic: Compare current 1-minute bar against recent SMA baseline
+- Mode: Real-time / near-real-time (polling GCS)
+- Purpose: Detect short-term price or volume spikes and notify via Slack
 
-v1 goals:
+Design goals:
 - Minimize false positives
-- Simple, explainable logic
-- No changes to streaming consumer
+- Simple, explainable rules
+- Independent from batch / Gold pipeline
 """
+
 
 import os
 import json
@@ -24,7 +26,7 @@ from google.cloud import storage
 
 
 # =========================
-# Config (v1 fixed)
+# Config (Streaming alert)
 # =========================
 WINDOW_MINUTES = 5
 PRICE_THRESHOLD = 0.015      # ±1.5%
@@ -313,7 +315,7 @@ class AlertWorker:
                 and not self.in_cooldown(market):
             
             message = (
-                f"🚨 *Streaming Alert (v1)*\n"
+                f"🚨 *Streaming Price & Volume Alert*\n"
                 f"Market: `{market}`\n"
                 f"Price change: {price_change:.2%}\n"
                 f"Volume ratio: {volume_ratio:.2f}\n"


### PR DESCRIPTION
## ✨ What
- Streaming / Daily Alert의 명칭과 역할을 목적 중심으로 정리

## 🎯 Why
- v1 / v2 용어로 인한 알림 역할 혼란 제거
- 사람이 바로 이해할 수 있는 알림 표현을 위함
- Closes #114

## 📌 Changes
- Streaming Alert docstring 및 Slack 제목 수정
- Daily Alert 명칭을 Daily Volatility Report로 통일

## 🧪 Test
- 코드 로직 변경 없음
- Slack 메시지 출력 포맷 확인

## 🤔 Review Point
- 명칭 및 표현 적절성만 확인
