### PR TITLE
feat(alert): separate streaming price and volume spike alerts

### DIFF
--- a/alerts/alert_worker.py
+++ b/alerts/alert_worker.py
@@ -5,7 +5,9 @@ Streaming Price & Volume Alert
 - Processing: Aggregate ticker events into 1-minute bars (price, volume)
 - Logic: Compare current 1-minute bar against recent SMA baseline
 - Mode: Real-time / near-real-time (polling GCS)
-- Purpose: Detect short-term price or volume spikes and notify via Slack
+- Purpose: Detect short-term price spikes and volume spikes separately
+            and notify via Slack
+
 
 Design goals:
 - Minimize false positives
@@ -29,8 +31,8 @@ from google.cloud import storage
 # Config (Streaming alert)
 # =========================
 WINDOW_MINUTES = 5
-PRICE_THRESHOLD = 0.015      # ±1.5%
-VOLUME_MULTIPLIER = 1.5     # 1.5x
+PRICE_THRESHOLD = 0.02      # ±2.0%
+VOLUME_MULTIPLIER = 4.5     # 4.5x
 COOLDOWN_SECONDS = 10 * 60
 POLL_SECONDS = 10
 
@@ -155,6 +157,37 @@ def send_slack(webhook: str, message: str):
     response = requests.post(webhook, json=payload, timeout=5)
     if response.status_code != 200:
         raise RuntimeError(f"Slack notification failed: {response.text}")
+    
+
+def send_price_spike_alert(
+    webhook: str,
+    market: str,
+    price_change: float,
+    minute: int,
+):
+    message = (
+        f"🚨 *Price Spike Alert (Streaming)*\n"
+        f"Market: `{market}`\n"
+        f"Price change: {price_change:.2%}\n"
+        f"Time (KST): {minute_to_str(minute)}"
+    )
+    send_slack(webhook, message)
+
+
+def send_volume_spike_alert(
+    webhook: str,
+    market: str,
+    volume_ratio: float,
+    minute: int,
+):
+    message = (
+        f"📊 *Volume Spike Alert (Streaming)*\n"
+        f"Market: `{market}`\n"
+        f"Volume ratio: {volume_ratio:.2f}x\n"
+        f"Time (KST): {minute_to_str(minute)}"
+    )
+    send_slack(webhook, message)
+
 
 # =========================
 # Alert Worker
@@ -310,23 +343,37 @@ class AlertWorker:
         price_change = (bar["close_price"] - avg_price) / avg_price
         volume_ratio = bar["volume"] / avg_volume
 
-        # if price OR volume condition met and not in cooldown:
-        if (abs(price_change) >= PRICE_THRESHOLD or volume_ratio >= VOLUME_MULTIPLIER) \
-                and not self.in_cooldown(market):
-            
-            message = (
-                f"🚨 *Streaming Price & Volume Alert*\n"
-                f"Market: `{market}`\n"
-                f"Price change: {price_change:.2%}\n"
-                f"Volume ratio: {volume_ratio:.2f}\n"
-                f"Time (KST): {minute_to_str(bar['minute'])}"
-            )
+        price_hit = abs(price_change) >= PRICE_THRESHOLD
+        volume_hit = volume_ratio >= VOLUME_MULTIPLIER
 
-            #   print alert (dry-run)
-            print(f"ALERT: {market} - {bar} (price_change: {price_change}, volume_ratio: {volume_ratio})")
-            send_slack(self.slack_webhook, message)
-            #   set cooldown
+        if price_hit and not self.in_cooldown(market):
+            print(
+                f"[Price Spike] {market} "
+                f"price_change={price_change:.2%} "
+                f"time={minute_to_str(bar['minute'])}"
+            )
+            send_price_spike_alert(
+                self.slack_webhook,
+                market,
+                price_change,
+                bar["minute"],
+            )
             self.set_cooldown(market)
+
+        if volume_hit and not self.in_cooldown(market):
+            print(
+                f"[Volume Spike] {market} "
+                f"volume_ratio={volume_ratio:.2f} "
+                f"time={minute_to_str(bar['minute'])}"
+            )
+            send_volume_spike_alert(
+                self.slack_webhook,
+                market,
+                volume_ratio,
+                bar["minute"],
+            )
+            self.set_cooldown(market)
+
 
     def run(self):
         """


### PR DESCRIPTION
## ✨ What
- Streaming Alert에서 가격 급변과 거래량 급증 신호를 분리

## 🎯 Why
- OR 조건으로 인한 알림 의미 혼합 문제 개선
- 운영 로그 기준 volume-only 이벤트가 다수 관측됨
- Closes #116

## 📌 Changes
- Price Spike / Volume Spike Alert 분리
- Slack 메시지 제목 및 내용 분리

## 🧪 Test
- 로컬 실행 및 Slack 메시지 출력 확인

## 🤔 Review Point
- 신호 분리 방식의 해석 가능성
