### PR TITLE
stock gold 추가

### DIFF
--- a/batch/dags/gold/stock_gold_dag.py
+++ b/batch/dags/gold/stock_gold_dag.py
@@ -1,0 +1,32 @@
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from datetime import datetime, timedelta
+from SlackAlert import send_slack_failure_callback
+
+default_args = {
+    'owner': 'airflow',
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+    'on_failure_callback': send_slack_failure_callback,
+}
+
+with DAG(
+    'stock_gold_dag',
+    default_args=default_args,
+    description='Run dbt gold models every 10 mins',
+    schedule_interval=None,  # 10분마다 실행
+    start_date=datetime(2025, 12, 29),
+    catchup=False,
+    max_active_runs=1 # 이전 작업 안 끝나면 대기
+) as dag:
+
+    # dbt run 실행
+    run_dbt = BashOperator(
+        task_id='dbt_run_gold',
+         bash_command=(
+            "cd /opt/dbt && "
+            "source /opt/dbt_venv/bin/activate && "
+            "dbt run --select gold_stock_ticker_trend gold_correlation_matrix"
+            
+        ),
+    )

--- a/batch/dags/silver/ticker_to_silver_gold_dag.py
+++ b/batch/dags/silver/ticker_to_silver_gold_dag.py
@@ -113,6 +113,12 @@ with DAG(
         trigger_dag_id='ticker_anomaly_detect_dag', 
         wait_for_completion=False 
     )
+
+    trigger_stock_gold = TriggerDagRunOperator(
+        task_id = 'trigger_stock_gold',
+        trigger_dag_id='stock_gold_dag',
+        wait_for_completion=False
+    )
  
-    load_upbit_data >> run_silver_ticker >> trigger_anomaly_detect
+    load_upbit_data >> run_silver_ticker >> ( trigger_anomaly_detect, trigger_stock_gold)
 

--- a/batch/dbt/models/gold/gold_correlation_matrix.sql
+++ b/batch/dbt/models/gold/gold_correlation_matrix.sql
@@ -1,0 +1,44 @@
+with stock_returns as (
+    select
+        CODE,
+        NAME,
+        to_timestamp(trade_date:VARCHAR || LPAD(trade_time::VARCHAR,6,'0'), 'YYYYMMDDHH24MISS') AS candle_time,
+        CLOSE_PRICE,
+        (CLOSE_PRICE - LAG(CLOSE_PRICE) OVER (PARTITION BY CODE ORDER BY TRADE_DATE, TRADE_TIME)) 
+        / NULLIF(LAG(CLOSE_PRICE) OVER (PARTITION BY CODE ORDER BY TRADE_DATE, TRADE_TIME),0) AS UPDOWN_RATE
+    FROM {{ ref('silver_stock')}}
+),
+
+ticker_returns as (
+    select 
+        code, 
+        DATE_TRUNC('MINUTE', trade_timestamp) AS candle_time,
+        AVG(trade_price) as avg_price,
+        (avg_price - LAG(avg_price) OVER (PARTITION BY code ORDER BY candle_time)) 
+        / NULLIF(LAG(avg_price) OVER (PARTITION BY code ORDER BY candle_time), 0) AS updown_rate
+    FROM {{ ref('silver_ticker') }}
+    GROUP BY 1, 2
+),
+
+joined_data as (
+    select 
+        s.name as stock_name,
+        c.code as ticker_code,
+        s.updown_rate as stock_return,
+        c.updown_rate as ticker_return
+    from stock_returns s 
+    inner join ticker_returns c 
+        on s.candle_time = c.candle_time
+    where s.updown_rate is not NULL
+        and c.updown_rate is not NULL
+)
+
+select 
+    stock_name,
+    ticker_code,
+    CORR(stock_return, ticker_return) as corrlation_coefficient,
+    count(*) as data_points
+from joined_data
+group by 1, 2
+having count(*) > 10
+order by 3 desc ;

--- a/batch/dbt/models/gold/gold_stock_ticker_trend.sql
+++ b/batch/dbt/models/gold/gold_stock_ticker_trend.sql
@@ -1,0 +1,26 @@
+with stock_1min as (
+    select 
+        CODE as ticker,
+        NAME as name,
+        'STOCK' as asset_type,
+        to_timestamp(trade_date || trade_time, 'YYYYMMDDHH24MISS') AS candle_time,
+        CLOSE_PRICE as price,
+        VOLUME as volume
+    from {{ ref('silver_stock') }}
+),
+
+ticker_1min as (
+    select 
+        code as ticker,
+        code as name,
+        "TICKER" as asset_type,
+        DATE_TRUNC('MINUTE', trade_timestamp) as candle_time,
+        avg(trade_price) as price,
+        sum(trade_volume) as volume
+    from {{ ref('silver_ticker')}}
+    group by 1,2,3,4
+)
+
+select * from stock_1min
+union all 
+select * from ticker_1min


### PR DESCRIPTION
## ✨ What
- gold 테이블 주식, 코인 상관관계 생성 
- gold 테이블 주식, 코인 1분 트렌드 비교 생성 
- 2개 테이블 생성하는 dag 생성 
- 위 dag trigger 하는 task를 ticker_to_silver_gold_dag에 추가 

## 🎯 Why
- gold 테이블 생성 
- 10분마다 테이블 업데이트 
- Closes #124 

## 📌 Changes
- 주요 변경사항 목록

## 🧪 Test
- 로컬에서 어떤 테스트를 거쳤는지

## 🤔 Review Point
- 주식이 열리지 않는 시간일 때 어떻게 보일지
- 상관관계는 왜곡돼서 나올 것 같아서... 주식 있는 시간만 상관관계 표시되게 함 
- 1분가격 추이 비교는 주식 없는 시간대에서는 종가로 비교 

