### PR TITLE
Fix CI rsync paths after batch to airflow rename

### DIFF
--- a/.github/workflows/deploy_dags.yml
+++ b/.github/workflows/deploy_dags.yml
@@ -35,10 +35,10 @@ jobs:
         run: |
           rsync -avz \
             --rsync-path="sudo rsync" \
-            batch/dags/raw/ \
-            batch/dags/silver/ \
-            batch/dags/gold/ \
-            batch/plugins/ \
+            airflow/dags/raw/ \
+            airflow/dags/silver/ \
+            airflow/dags/gold/ \
+            airflow/plugins/ \
             ${{ secrets.AIRFLOW_USER }}@${{ secrets.AIRFLOW_CORE_IP }}:/home/${{ secrets.AIRFLOW_USER }}/airflow/dags/
 
       - name: Rebuild Core
@@ -62,15 +62,15 @@ jobs:
         run: |
           rsync -avz \
             --rsync-path="sudo rsync" \
-            batch/dags/raw/ \
-            batch/dags/silver/ \
-            batch/dags/gold/ \
-            batch/plugins/ \
+            airflow/dags/raw/ \
+            airflow/dags/silver/ \
+            airflow/dags/gold/ \
+            airflow/plugins/ \
             ${{ secrets.AIRFLOW_USER }}@${{ secrets.AIRFLOW_WORKER_IP }}:/home/${{ secrets.AIRFLOW_USER }}/airflow/dags/ &&
 
           rsync -avz \
             --rsync-path="sudo rsync" \
-            batch/dbt \
+            airflow/dbt \
             ${{ secrets.AIRFLOW_USER }}@${{ secrets.AIRFLOW_WORKER_IP }}:/home/${{ secrets.AIRFLOW_USER }}/ &&
 
           ssh ${{ secrets.AIRFLOW_USER }}@${{ secrets.AIRFLOW_WORKER_IP }} "


### PR DESCRIPTION
## ✨ What
- GitHub Actions CD 워크플로우에서 rsync 대상 경로를 `batch/*` → `airflow/*`로 수정
- 디렉토리 rename 이후 깨졌던 DAG / plugin 배포 로직 복구

## 🎯 Why
- `batch` 디렉토리를 `airflow`로 변경한 이후 CI에서 존재하지 않는 경로를 참조하며 rsync가 실패하고 있었음
- CD 파이프라인이 중단되어 Airflow DAG 및 plugin 배포가 불가능한 상태였음  
- Closes #132 

## 📌 Changes
- `deploy_dags.yml`
  - Core / Worker 배포 단계의 rsync source path를 `airflow/*` 기준으로 수정
  - `batch/dbt` → `airflow/dbt` 경로 수정

## 🧪 Test
- GitHub Actions CD 워크플로우 재실행
- rsync 단계 정상 통과 확인
- Core / Worker 서버에 DAGs 및 plugins 정상 배포 확인

## 🤔 Review Point
- 이번 PR은 디렉토리 rename에 따른 CI 설정 불일치 수정에만 집중한 최소 변경 사항입니다
- 추후 디렉토리 구조 변경 시 CD 안정성을 높이기 위해 rsync 전 존재 여부 체크 로직을 추가하는 방안을 고려할 수 있습니다
