### PR TITLE
Fix CI rsync path for dbt after moving to repo root

### DIFF
--- a/.github/workflows/deploy_dags.yml
+++ b/.github/workflows/deploy_dags.yml
@@ -70,7 +70,7 @@ jobs:
 
           rsync -avz \
             --rsync-path="sudo rsync" \
-            airflow/dbt \
+            dbt/ \
             ${{ secrets.AIRFLOW_USER }}@${{ secrets.AIRFLOW_WORKER_IP }}:/home/${{ secrets.AIRFLOW_USER }}/ &&
 
           ssh ${{ secrets.AIRFLOW_USER }}@${{ secrets.AIRFLOW_WORKER_IP }} "


### PR DESCRIPTION
## ✨ What
- Worker 배포 단계에서 dbt rsync source 경로를 repo 최상위(`dbt/`) 기준으로 수정

## 🎯 Why
- dbt 디렉토리를 repo 최상위로 이동한 이후 CI에서 잘못된 경로(`airflow/dbt`)를 참조하며 배포가 실패하고 있었음  
- Closes #134 

## 📌 Changes
- `deploy_dags.yml`
  - dbt rsync source path를 `airflow/dbt` → `dbt/`로 수정

## 🧪 Test
- GitHub Actions CD 워크플로우 재실행
- rsync 단계 정상 통과 확인
- Worker 서버에 dbt 디렉토리 정상 배포 확인

## 🤔 Review Point
- 이번 PR은 dbt 디렉토리 이동에 따른 CI 설정 불일치 수정에만 집중한 최소 변경 사항입니다
